### PR TITLE
Texts working with dark theme

### DIFF
--- a/packages/ui/src/palette.tsx
+++ b/packages/ui/src/palette.tsx
@@ -1,9 +1,15 @@
+/* CSS Variables */
+const textPrimary = 'var(--text-primary)';
+const textSecondary = 'var(--text-secondary)';
+
 const white = '#FFFFFF';
 const black = '#000000';
 
 export const palette = {
     black,
     white,
+    textPrimary,
+    textSecondary,
     primary: {
         contrastText: black,
         dark: '#84D901',

--- a/packages/ui/src/typography.tsx
+++ b/packages/ui/src/typography.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {createUseStyles} from './styles';
+import {createUseStyles, useTheme} from './styles';
 import {typos} from './typos';
 import classnames from 'classnames';
 
@@ -30,6 +30,19 @@ const useStyles = createUseStyles(() => ({
     },
 }));
 
+type TextProps = {
+    children: React.ReactNode;
+    className?: string;
+    style?: any;
+    color?: string;
+    as?: keyof JSX.IntrinsicElements;
+};
+
+const Text = ({color, as = 'span', className, style, children}: TextProps) => {
+    const {palette} = useTheme();
+    return React.createElement(as, {className, style, color: color || palette.textPrimary}, children);
+};
+
 interface Props {
     gutterBottom?: 0 | 4 | 8 | 16 | 32;
     ellipsis?: boolean;
@@ -41,15 +54,12 @@ interface Props {
         | 'h3'
         | 'h4'
         | 'h5'
-        | 'h6'
         | 'body1'
         | 'body2'
         | 'subtitle1'
         | 'subtitle2'
-        | 'button'
         | 'caption1'
-        | 'caption2'
-        | 'overline';
+        | 'caption2';
     color?: string;
     style?: React.CSSProperties;
 }
@@ -70,7 +80,8 @@ export const Typography = ({
     switch (variant) {
         case 'h1':
             return (
-                <h1
+                <Text
+                    as="h1"
                     className={classnames(
                         classes.h1,
                         {[classes.ellipsis]: ellipsis, [classes.center]: center},
@@ -86,11 +97,12 @@ export const Typography = ({
                     {...props}
                 >
                     {children}
-                </h1>
+                </Text>
             );
         case 'h2':
             return (
-                <h2
+                <Text
+                    as="h2"
                     className={classnames(
                         classes.h2,
                         {[classes.ellipsis]: ellipsis, [classes.center]: center},
@@ -106,7 +118,7 @@ export const Typography = ({
                     {...props}
                 >
                     {children}
-                </h2>
+                </Text>
             );
         case 'h3':
             return (
@@ -130,7 +142,8 @@ export const Typography = ({
             );
         case 'h4':
             return (
-                <h4
+                <Text
+                    as="h4"
                     className={classnames(
                         classes.h4,
                         {[classes.ellipsis]: ellipsis, [classes.center]: center},
@@ -146,11 +159,12 @@ export const Typography = ({
                     {...props}
                 >
                     {children}
-                </h4>
+                </Text>
             );
         case 'h5':
             return (
-                <h5
+                <Text
+                    as="h5"
                     className={classnames(
                         classes.h5,
                         {[classes.ellipsis]: ellipsis, [classes.center]: center},
@@ -166,30 +180,12 @@ export const Typography = ({
                     {...props}
                 >
                     {children}
-                </h5>
-            );
-        case 'h6':
-            return (
-                <h6
-                    className={classnames(
-                        classes.h6,
-                        {[classes.ellipsis]: ellipsis, [classes.center]: center},
-                        className
-                    )}
-                    style={{
-                        marginBottom: gutterBottom,
-                        ...(ellipsis ? {WebkitLineClamp: lineClamp} : {}),
-                        ...(color ? {color} : {}),
-                        ...style,
-                    }}
-                    {...props}
-                >
-                    {children}
-                </h6>
+                </Text>
             );
         case 'body1':
             return (
-                <p
+                <Text
+                    as="p"
                     className={classnames(
                         classes.body1,
                         {[classes.ellipsis]: ellipsis, [classes.center]: center},
@@ -204,11 +200,12 @@ export const Typography = ({
                     {...props}
                 >
                     {children}
-                </p>
+                </Text>
             );
         case 'body2':
             return (
-                <p
+                <Text
+                    as="p"
                     className={classnames(
                         classes.body2,
                         {[classes.ellipsis]: ellipsis, [classes.center]: center},
@@ -224,11 +221,12 @@ export const Typography = ({
                     {...props}
                 >
                     {children}
-                </p>
+                </Text>
             );
         case 'subtitle1':
             return (
-                <span
+                <Text
+                    as="span"
                     className={classnames(
                         classes.subtitle1,
                         {[classes.ellipsis]: ellipsis, [classes.center]: center},
@@ -244,11 +242,12 @@ export const Typography = ({
                     {...props}
                 >
                     {children}
-                </span>
+                </Text>
             );
         case 'subtitle2':
             return (
-                <span
+                <Text
+                    as="span"
                     className={classnames(
                         classes.subtitle2,
                         {[classes.ellipsis]: ellipsis, [classes.center]: center},
@@ -264,31 +263,12 @@ export const Typography = ({
                     {...props}
                 >
                     {children}
-                </span>
-            );
-        case 'button':
-            return (
-                <p
-                    className={classnames(
-                        classes.button,
-                        {[classes.ellipsis]: ellipsis, [classes.center]: center},
-                        className
-                    )}
-                    style={{
-                        marginBottom: gutterBottom,
-                        ...(gutterBottom !== 0 && !ellipsis ? {display: 'block'} : {}),
-                        ...(ellipsis ? {WebkitLineClamp: lineClamp} : {}),
-                        ...(color ? {color} : {}),
-                        ...style,
-                    }}
-                    {...props}
-                >
-                    {children}
-                </p>
+                </Text>
             );
         case 'caption1':
             return (
-                <p
+                <Text
+                    as="p"
                     className={classnames(
                         classes.caption,
                         {[classes.ellipsis]: ellipsis, [classes.center]: center},
@@ -304,11 +284,12 @@ export const Typography = ({
                     {...props}
                 >
                     {children}
-                </p>
+                </Text>
             );
         case 'caption2':
             return (
-                <p
+                <Text
+                    as="p"
                     className={classnames(
                         classes.caption2,
                         {[classes.ellipsis]: ellipsis, [classes.center]: center},
@@ -324,31 +305,11 @@ export const Typography = ({
                     {...props}
                 >
                     {children}
-                </p>
-            );
-        case 'overline':
-            return (
-                <p
-                    className={classnames(
-                        classes.overline,
-                        {[classes.ellipsis]: ellipsis, [classes.center]: center},
-                        className
-                    )}
-                    style={{
-                        marginBottom: gutterBottom,
-                        ...(gutterBottom !== 0 && !ellipsis ? {display: 'block'} : {}),
-                        ...(ellipsis ? {WebkitLineClamp: lineClamp} : {}),
-                        ...(color ? {color} : {}),
-                        ...style,
-                    }}
-                    {...props}
-                >
-                    {children}
-                </p>
+                </Text>
             );
         default:
             return (
-                <p
+                <Text
                     className={classnames(
                         classes.body1,
                         {[classes.ellipsis]: ellipsis, [classes.center]: center},
@@ -364,7 +325,7 @@ export const Typography = ({
                     {...props}
                 >
                     {children}
-                </p>
+                </Text>
             );
     }
 };

--- a/packages/ui/src/typos.tsx
+++ b/packages/ui/src/typos.tsx
@@ -3,7 +3,7 @@ import {palette} from './palette';
 
 export const typos = {
     h1: {
-        color: palette.text.primary,
+        color: palette.textPrimary,
         fontWeight: 500,
         fontSize: 32,
         letterSpacing: '-0.24px',
@@ -11,7 +11,7 @@ export const typos = {
         fontSmoothing: 'antialiased',
     },
     h2: {
-        color: palette.text.primary,
+        color: palette.textPrimary,
         fontWeight: 500,
         fontSize: 24,
         letterSpacing: '-0.24px',
@@ -19,7 +19,7 @@ export const typos = {
         fontSmoothing: 'antialiased',
     },
     h3: {
-        color: palette.text.primary,
+        color: palette.textPrimary,
         fontWeight: 500,
         fontSize: 20,
         letterSpacing: '-0.2px',
@@ -27,7 +27,7 @@ export const typos = {
         fontSmoothing: 'antialiased',
     },
     h4: {
-        color: palette.text.primary,
+        color: palette.textPrimary,
         fontWeight: 500,
         fontSize: '20px',
         letterSpacing: '-0.06px',
@@ -35,7 +35,7 @@ export const typos = {
         fontSmoothing: 'antialiased',
     },
     h5: {
-        color: palette.text.primary,
+        color: palette.textPrimary,
         fontWeight: 500,
         fontSize: '16px',
         letterSpacing: '-0.05px',
@@ -43,7 +43,7 @@ export const typos = {
         fontSmoothing: 'antialiased',
     },
     h6: {
-        color: palette.text.primary,
+        color: palette.textPrimary,
         fontWeight: 500,
         fontSize: '16px',
         letterSpacing: '-0.05px',
@@ -51,21 +51,21 @@ export const typos = {
         fontSmoothing: 'antialiased',
     },
     body1: {
-        color: palette.text.primary,
+        color: palette.textPrimary,
         fontSize: 14,
         letterSpacing: 'normal',
         lineHeight: 1.3,
         fontSmoothing: 'antialiased',
     },
     body2: {
-        color: palette.text.primary,
+        color: palette.textPrimary,
         fontSize: 12,
         letterSpacing: '-0.05px',
         lineHeight: 1.2,
         fontSmoothing: 'antialiased',
     },
     subtitle1: {
-        color: palette.text.secondary,
+        color: palette.textSecondary,
         fontWeight: 500,
         fontSize: 14,
         letterSpacing: '-0.05px',
@@ -73,7 +73,7 @@ export const typos = {
         fontSmoothing: 'antialiased',
     },
     subtitle2: {
-        color: palette.text.secondary,
+        color: palette.textSecondary,
         fontWeight: 500,
         fontSize: 12,
         letterSpacing: '-0.05px',
@@ -81,12 +81,12 @@ export const typos = {
         fontSmoothing: 'antialiased',
     },
     button: {
-        color: palette.text.primary,
+        color: palette.textPrimary,
         fontSize: 14,
         fontSmoothing: 'antialiased',
     },
     caption: {
-        color: palette.text.primary,
+        color: palette.textPrimary,
         fontSize: 14,
         fontWeight: 600,
         letterSpacing: 'normal',
@@ -94,7 +94,7 @@ export const typos = {
         fontSmoothing: 'antialiased',
     },
     caption2: {
-        color: palette.text.primary,
+        color: palette.textPrimary,
         fontSize: 12,
         fontWeight: 600,
         letterSpacing: '-0.05px',

--- a/packages/ui/theme.css
+++ b/packages/ui/theme.css
@@ -1,6 +1,19 @@
 /* Ionic Variables and Theming. For more info, please see:
 http://ionicframework.com/docs/theming/ */
 
+/* Colors */
+:root {
+    --text-primary: #000000;
+    --text-secondary: #92949c;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text-primary: #ffffff;
+        --text-secondary: #92949c;
+    }
+}
+
 /** Ionic CSS Variables **/
 :root {
     /** primary **/
@@ -78,9 +91,9 @@ http://ionicframework.com/docs/theming/ */
 
 @media (prefers-color-scheme: dark) {
     /*
-   * Dark Colors
-   * -------------------------------------------
-   */
+     * Dark Colors
+     * -------------------------------------------
+     */
 
     body {
         --ion-color-primary: #428cff;
@@ -148,9 +161,9 @@ http://ionicframework.com/docs/theming/ */
     }
 
     /*
-   * iOS Dark Theme
-   * -------------------------------------------
-   */
+     * iOS Dark Theme
+     * -------------------------------------------
+     */
 
     .ios body {
         --ion-background-color: #000000;
@@ -187,9 +200,9 @@ http://ionicframework.com/docs/theming/ */
     }
 
     /*
-   * Material Design Dark Theme
-   * -------------------------------------------
-   */
+     * Material Design Dark Theme
+     * -------------------------------------------
+     */
 
     .md body {
         --ion-background-color: #121212;


### PR DESCRIPTION
Built on top of #51 

* Added two CSS custom properties for primary and secondary text colors, and defined for the dark theme too.
* Used them in the text styles.
* Now `Typography` now uses a new private component `Text`, in advance of stop using the verbose `<Typography variant="h1">` and use just `<H1>`, that innerly will use `Text`.

![image](https://user-images.githubusercontent.com/4521712/123543483-fc955c80-d74e-11eb-807c-963fa5510258.png)
![image](https://user-images.githubusercontent.com/4521712/123543484-fdc68980-d74e-11eb-8549-2938f8c2bab6.png)
